### PR TITLE
[sshd] Enable systemd support #19

### DIFF
--- a/cookbooks/system/sshd/recipes/config.rb
+++ b/cookbooks/system/sshd/recipes/config.rb
@@ -12,7 +12,7 @@ template '/etc/ssh/sshd_config' do
 end
 
 service 'ssh' do
-  provider Chef::Provider::Service::Upstart
-  action [ :enable ]
-  supports status: true, start: true, stop: true, restart: true
+  action :enable
+  supports status: true, start: true, stop: true, restart: true, reload: true
 end
+

--- a/cookbooks/system/sshd/recipes/config.rb
+++ b/cookbooks/system/sshd/recipes/config.rb
@@ -12,7 +12,9 @@ template '/etc/ssh/sshd_config' do
 end
 
 service 'ssh' do
-  action :enable
-  supports status: true, start: true, stop: true, restart: true, reload: true
+  if node['platform'] == 'ubuntu' && node['platform_version'].to_f < 15.04
+    provider Chef::Provider::Service::Upstart
+  end
+  action [:enable, :start]
+  supports [:status, :start, :stop, :restart, :reload]
 end
-


### PR DESCRIPTION
I suppose this is backwards compatible? Not specifying the provider lets chef choose the correct one at runtime.
