### PR TITLE
[passenger] Remove passenger_max_pool_size

### DIFF
--- a/cookbooks/software/passenger/templates/default/nginx.conf.erb
+++ b/cookbooks/software/passenger/templates/default/nginx.conf.erb
@@ -27,7 +27,6 @@ http {
 
   passenger_spawn_method smart;
   passenger_friendly_error_pages off;
-  passenger_max_pool_size 40;
 
   rails_env <%= node.chef_environment %>;
 


### PR DESCRIPTION
Instead of having this super high `passenger_max_pool_size` we should use the default of 6.
The apps can override this setting in a `before` file.